### PR TITLE
[FEATURE] fix sorting function to sort strings OR numbers

### DIFF
--- a/src/Utils/utilityFunctions.ts
+++ b/src/Utils/utilityFunctions.ts
@@ -31,11 +31,13 @@ const compareValues = (key: any, order = 'asc') => {
       // property doesn't exist on either object
       return 0;
     }
+    // checks if string is actually a string of numbers
+    const isNum = (val: string) => (/^\d+$/.test(val));
 
-    const varA = (typeof a[key] === 'string')
-      ? a[key].toUpperCase() : a[key];
-    const varB = (typeof b[key] === 'string')
-      ? b[key].toUpperCase() : b[key];
+    const varA = (typeof a[key] === 'string' && isNum(a[key]) === false)
+      ? a[key].toUpperCase() : parseInt(a[key], 10);
+    const varB = (typeof b[key] === 'string' && isNum(b[key]) === false)
+      ? b[key].toUpperCase() : parseInt(b[key], 10);
 
     let comparison = 0;
     if (varA > varB) {


### PR DESCRIPTION
## What is this?
This PR fixes the `compareValues` function for sorting the array of objects.  

The short story is that this function worked great except for that the json for height, mass, etc was in string format (rather than a number), so I created an inner function that checked if the string contained only numbers using a regex, and if so, return a truthy or falsy value.

If the string was a string of numbers, I then used `parseInt` to take the values and convert the string to a number.  Otherwise, just use the string as-is.

## How was it implemented?
- create an `isNum` function that takes in a string and tests for the content of the string
- if truthy, `parseInt` the value
- if falsy, go about as normal.

## Blockers?
No, but I'm not 100% sure the date is sorting correctly.  It looks like it works, but the entries were all made or edited close to one another.

## Ticket #
[SWL-23](https://trello.com/c/QGZBhGAH)